### PR TITLE
pass POST parameters in body, not URL

### DIFF
--- a/jenkins.go
+++ b/jenkins.go
@@ -10,6 +10,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"strings"
 )
 
 type Auth struct {
@@ -107,10 +108,20 @@ func (jenkins *Jenkins) getXml(path string, params url.Values, body interface{})
 }
 
 func (jenkins *Jenkins) post(path string, params url.Values, body interface{}) (err error) {
-	requestUrl := jenkins.buildUrl(path, params)
-	req, err := http.NewRequest("POST", requestUrl, nil)
+	requestUrl := jenkins.buildUrl(path, nil)
+
+	var bodyReader io.Reader
+	if params != nil {
+		bodyReader = strings.NewReader(params.Encode())
+	}
+
+	req, err := http.NewRequest("POST", requestUrl, bodyReader)
 	if err != nil {
 		return
+	}
+
+	if params != nil {
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	}
 
 	resp, err := jenkins.sendRequest(req)


### PR DESCRIPTION
to avoid 414's due to URL length limit when parameter values are big

Tested locally (manually). (There is no working test suite in this repo. We may want to consider switching to a different library, e.g. https://github.com/bndr/gojenkins)