### PR TITLE
Allow for pulling detailed build information from a single GetJob request

### DIFF
--- a/jenkins.go
+++ b/jenkins.go
@@ -170,8 +170,8 @@ func (jenkins *Jenkins) GetJobs() ([]Job, error) {
 }
 
 // GetJob returns a job which has specified name.
-func (jenkins *Jenkins) GetJob(name string) (job Job, err error) {
-	err = jenkins.get(fmt.Sprintf("/job/%s", name), nil, &job)
+func (jenkins *Jenkins) GetJob(name string, params url.Values) (job Job, err error) {
+	err = jenkins.get(fmt.Sprintf("/job/%s", name), params, &job)
 	return
 }
 

--- a/job.go
+++ b/job.go
@@ -46,12 +46,13 @@ type Job struct {
 	Description  string   `json:"description"`
 	HealthReport []Health `json:"healthReport"`
 
-	LastCompletedBuild    Build `json:"lastCompletedBuild"`
-	LastFailedBuild       Build `json:"lastFailedBuild"`
-	LastStableBuild       Build `json:"lastStableBuild"`
-	LastSuccessfulBuild   Build `json:"lastSuccessfulBuild"`
-	LastUnstableBuild     Build `json:"lastUnstableBuild"`
-	LastUnsuccessfulBuild Build `json:"lastUnsuccessfulBuild"`
+	Builds                []Build `json:"builds"`
+	LastCompletedBuild    Build   `json:"lastCompletedBuild"`
+	LastFailedBuild       Build   `json:"lastFailedBuild"`
+	LastStableBuild       Build   `json:"lastStableBuild"`
+	LastSuccessfulBuild   Build   `json:"lastSuccessfulBuild"`
+	LastUnstableBuild     Build   `json:"lastUnstableBuild"`
+	LastUnsuccessfulBuild Build   `json:"lastUnsuccessfulBuild"`
 }
 
 type Health struct {

--- a/queue.go
+++ b/queue.go
@@ -22,6 +22,7 @@ type Item struct {
 type Action struct {
 	Causes               []Cause               `json:"causes"`
 	ParameterDefinitions []ParameterDefinition `json:"parameterDefinitions"`
+	Parameters           []Parameter           `json:"parameter"`
 }
 
 type Cause struct {
@@ -33,6 +34,11 @@ type Cause struct {
 
 type ParameterDefinition struct {
 	Name string `json:"name"`
+}
+
+type Parameter struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
 }
 
 type Task struct {


### PR DESCRIPTION
Adds a `params` parameter to `GetJob` so we can pass along things like `depth=1` or more custom tree filters. This also adds the `builds` array of builds to the `Job` struct and further structs for build parameters, all of which are included in a depth 1 request.