### PR TITLE
Make parameter values interface{}

### DIFF
--- a/queue.go
+++ b/queue.go
@@ -37,8 +37,8 @@ type ParameterDefinition struct {
 }
 
 type Parameter struct {
-	Name  string `json:"name"`
-	Value string `json:"value"`
+	Name  string      `json:"name"`
+	Value interface{} `json:"value"`
 }
 
 type Task struct {


### PR DESCRIPTION
Because their type could be anything.

@msneeden  @johannespetzold @mikesol314 